### PR TITLE
feat: Add tugboat configuration

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,0 +1,215 @@
+# Default Drupal 10 Tugboat starter config.
+# https://docs.tugboatqa.com/starter-configs/tutorials/drupal-10/
+services:
+  storage:
+    image: tugboatqa/debian:bookworm
+    commands:
+      init:
+        - |
+          wget https://dl.min.io/server/minio/release/linux-amd64/minio
+          chmod +x minio
+          mkdir /data
+          mkdir -p /etc/service/minio
+          echo "#!/bin/sh" > /etc/service/minio/run
+          echo "/minio server /data" >> /etc/service/minio/run
+          chmod +x /etc/service/minio/run
+
+  # Define the database service.
+  database:
+    # Use the latest available 5.x version of MySQL
+    image: tugboatqa/mariadb:10.5
+
+    # A set of commands to run while building this service
+    commands:
+      # Configure the server for the site to run on.
+      init:
+        # Increase the allowed packet size to 512MB.
+        - mysql -e "SET GLOBAL max_allowed_packet=536870912;"
+        # Ensure this packet size persists even if MySQL restarts.
+        - echo "max_allowed_packet=536870912" >> /etc/mysql/conf.d/tugboat.cnf
+
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update: []
+
+      # Run any commands needed to prepare the site.  This is generally not needed
+      # for database services.
+      build: []
+
+  # Define the webserver service.
+  webserver:
+    image: tugboatqa/php:8.3-apache
+    expose: 80
+    checkout: true
+    depends:
+      - database
+      - storage
+
+    # A set of commands to run while building this service
+    commands:
+      # The INIT command configures the webserver.
+      init:
+        # Install opcache and mod-rewrite.
+        - |
+          apt update && apt install -y libzip4 libzip-dev
+          docker-php-ext-install opcache zip
+          a2enmod headers rewrite
+        # Install MinIO client.
+        - |
+          curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o $HOME/minio-binaries/mc
+          chmod +x $HOME/minio-binaries/mc
+        # Set up MinIO client.
+        - |
+          $HOME/minio-binaries/mc alias set storage http://storage:9000 minioadmin minioadmin
+          $HOME/minio-binaries/mc mb storage/urls
+        # Link the document root to the expected path. This example links /web
+        # to the docroot.
+        - ln -snf "${TUGBOAT_ROOT}/web" "${DOCROOT}"
+
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update:
+        ## Install Drupal
+        - |
+          composer require drush/drush
+          composer install
+          vendor/bin/drush site:install minimal --db-url=mysql://tugboat:tugboat@database/tugboat --account-name=drupaldecoupled --account-pass=drupaldecoupled -y
+        # Apply local settings patch
+        - git apply "${TUGBOAT_ROOT}/.tugboat/patches/enable-local-settings.patch" || true
+        # Set the tugboat-specific Drupal settings.
+        - cp "${TUGBOAT_ROOT}/.tugboat/settings.local.php" "${DOCROOT}/sites/default/settings.local.php"
+        # Copy the consumer generation script to the docroot.
+        - cp "${TUGBOAT_ROOT}/.tugboat/replace_preview_consumer.php" "${DOCROOT}/../replace_preview_consumer.php"
+
+        ## Update Composer minimum-stability
+        - composer config minimum-stability --merge --json "dev"
+
+        ## Update Composer to support patching
+        - |
+          composer config allow-plugins.cweagans/composer-patches true
+          composer config --json extra.composer-exit-on-patch-failure true
+          composer config --json extra.patches.drupal/paragraphs { "Add UUID to table row": "patches/paragraphs-add-uuid-to-table-row.patch" }
+          composer require cweagans/composer-patches
+        ## Extend Drupal using Recipes
+        - |
+          composer require octahedroid/drupal-decoupled-graphql-advanced-recipe
+          cd $DOCROOT && php ${DOCROOT}/core/scripts/drupal recipe ${DOCROOT}/../recipes/drupal-decoupled-graphql-advanced-recipe
+
+        ## Update Composer to support unpacking
+        - |
+          composer config allow-plugins.ewcomposer/unpack true
+          composer config repo.recipe-unpack vcs https://github.com/woredeyonas/Drupal-Recipe-Unpack.git
+          composer require ewcomposer/unpack:dev-master
+          composer unpack octahedroid/drupal-decoupled-graphql-advanced-recipe
+          composer require drush/drush
+          composer install
+
+        ## Generate consumers
+        - vendor/bin/drush php:script scripts/consumers
+
+        ## Rebuild permissions
+        - |
+          vendor/bin/drush php-eval 'node_access_rebuild();'
+          vendor/bin/drush cr
+
+        # Make sure our files and translations folders exists and are writable.
+        - |
+          mkdir -p "${DOCROOT}/sites/default/files/translations"
+          chgrp -R www-data "${DOCROOT}/sites/default/files"
+          find "${DOCROOT}/sites/default/files" -type d -exec chmod 2775 {} \;
+          find "${DOCROOT}/sites/default/files" -type f -exec chmod 0664 {} \;
+          chgrp -R www-data "${DOCROOT}/../keys"
+          find "${DOCROOT}/../keys" -type f -exec chmod 0660 {} \;
+
+      # Commands that build the site. This is where you would add things
+      # like feature reverts or any other drush commands required to
+      # set up or configure the site. When a preview is built from a
+      # base preview, the build workflow starts here, skipping the init
+      # and update steps, because the results of those are inherited
+      # from the base preview.
+      build:
+        # Install new configuration and database updates.
+        - |
+          vendor/bin/drush cache:rebuild
+          vendor/bin/drush config:export --yes && vendor/bin/drush config:import --yes
+          vendor/bin/drush updatedb --yes
+
+        # Write webserver public URL stored on minio(storage).
+        - |
+          echo "${TUGBOAT_SERVICE_URL%/}" > webserver-url && $HOME/minio-binaries/mc put webserver-url storage/urls
+          vendor/bin/drush php:script replace_preview_consumer
+
+        # One last cache rebuild.
+        - vendor/bin/drush cache:rebuild
+        # Generate a one-time login link.
+        - vendor/bin/drush uli -l $TUGBOAT_SERVICE_URL
+
+  frontend:
+    image: tugboatqa/debian:bookworm
+    depends:
+      - webserver
+      - storage
+    expose: 8080
+    default: true
+    volumes:
+      - share:/share
+    commands:
+      init:
+        - |
+          mkdir -p /etc/service/frontend
+          apt update && apt install -y git curl
+        # Install MinIO client.
+        - |
+          curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o $HOME/minio-binaries/mc
+          chmod +x $HOME/minio-binaries/mc
+        # Set up MinIO client.
+        - $HOME/minio-binaries/mc alias set storage http://storage:9000 minioadmin minioadmin
+        # Install Node.js and Yarn.
+        - |
+          curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && bash nodesource_setup.sh
+          apt install -y nodejs
+          npm install -g yarn
+        # Clone the repository into the service container.
+        - |
+          mkdir -p $(dirname /var/lib/tugboat-fe)
+          git clone https://github.com/octahedroid/drupal-decoupled.git /var/lib/tugboat-fe --depth=1
+      update: []
+      build:
+        # Set the frontend framework, replace this line with the framework you are using.
+        - echo "next" > /etc/service/frontend/framework
+        # Set up environment variables.
+        - |
+          echo "DRUPAL_CLIENT_ID=${TUGBOAT_DEFAULT_SERVICE_ID}" > /etc/service/frontend/.env
+          echo "DRUPAL_CLIENT_SECRET=${TUGBOAT_PREVIEW_ID}${TUGBOAT_DEFAULT_SERVICE_TOKEN}" >> /etc/service/frontend/.env
+          echo "DRUPAL_AUTH_URI=$($HOME/minio-binaries/mc cat storage/urls/webserver-url)" >> /etc/service/frontend/.env
+          echo "DRUPAL_GRAPHQL_URI=$($HOME/minio-binaries/mc cat storage/urls/webserver-url)/graphql" >> /etc/service/frontend/.env
+          echo "ENVIRONMENT=preview" >> /etc/service/frontend/.env
+          echo "NODE_VERSION=v20.10.0" >> /etc/service/frontend/.env
+        - |
+          case $(cat /etc/service/frontend/framework) in
+            next)
+              echo "--hostname" > /etc/service/frontend/hostname-flag
+              cp /etc/service/frontend/.env /var/lib/tugboat-fe/starters/$(cat /etc/service/frontend/framework)/.env.local
+            ;;
+            remix)
+              echo "--ip" > /etc/service/frontend/hostname-flag
+              cp /etc/service/frontend/.env /var/lib/tugboat-fe/starters/$(cat /etc/service/frontend/framework)/.dev.vars
+            ;;
+          esac
+
+        # Install framework dependencies.
+        - cd /var/lib/tugboat-fe/starters/$(cat /etc/service/frontend/framework) && yarn install
+        # Build the frontend.
+        - cd /var/lib/tugboat-fe/starters/$(cat /etc/service/frontend/framework) && yarn build
+        # Create the service runit script.
+        - |
+          echo "#!/bin/sh" > /etc/service/frontend/run
+          echo "cd /var/lib/tugboat-fe/starters/$(cat /etc/service/frontend/framework) && yarn start --port 8080 $(cat /etc/service/frontend/hostname-flag) 0.0.0.0" >> /etc/service/frontend/run
+          chmod +x /etc/service/frontend/run
+        # Warm the cache
+        - 'wget -e robots=off --quiet --page-requisites --delete-after --header "Host: ${TUGBOAT_SERVICE_URL_HOST}" http://localhost:8080
+          || /bin/true'

--- a/.tugboat/patches/enable-local-settings.patch
+++ b/.tugboat/patches/enable-local-settings.patch
@@ -1,0 +1,17 @@
+diff --git a/web/sites/default/settings.php b/web/sites/default/settings.php
+index 9e0b214..c7d2c2b 100644
+--- a/web/sites/default/settings.php
++++ b/web/sites/default/settings.php
+@@ -887,9 +887,9 @@
+  * Keep this code block at the end of this file to take full effect.
+  */
+ #
+-# if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+-#   include $app_root . '/' . $site_path . '/settings.local.php';
+-# }
++if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
++  include $app_root . '/' . $site_path . '/settings.local.php';
++}
+ $databases['default']['default'] = array (
+   'database' => 'tugboat',
+   'username' => 'tugboat',

--- a/.tugboat/replace_preview_consumer.php
+++ b/.tugboat/replace_preview_consumer.php
@@ -1,0 +1,26 @@
+<?php
+
+$consumerStorage = \Drupal::entityTypeManager()->getStorage("consumer");
+
+$previewerClientId = getenv("TUGBOAT_DEFAULT_SERVICE_ID");
+$previewerClientSecret =
+    getenv("TUGBOAT_PREVIEW_ID") . getenv("TUGBOAT_DEFAULT_SERVICE_TOKEN");
+
+$previewers = $consumerStorage->loadByProperties([
+    "label" => "Previewer",
+]);
+foreach ($previewers as $previewer) {
+    $previewer->delete();
+}
+
+$consumerStorage
+    ->create([
+        "client_id" => $previewerClientId,
+        "client_secret " => $previewerClientSecret,
+        "label" => "Previewer",
+        "user_id" => 2,
+        "third_party" => true,
+        "is_default" => false,
+        "roles" => ["previewer"],
+    ])
+    ->save();

--- a/.tugboat/settings.local.php
+++ b/.tugboat/settings.local.php
@@ -1,0 +1,12 @@
+<?php
+// Use the TUGBOAT_REPO_ID to generate a hash salt for Tugboat sites.
+$settings["hash_salt"] = hash("sha256", getenv("TUGBOAT_REPO_ID"));
+
+global $config;
+$tugboatHost =
+    getenv("TUGBOAT_DEFAULT_SERVICE_URL_PROTOCOL") .
+    "://" .
+    getenv("TUGBOAT_DEFAULT_SERVICE_URL_HOST");
+$config["decoupled_preview_iframe.settings"]["redirect_anonymous"] = false;
+$config["decoupled_preview_iframe.settings"]["redirect_url"] = $tugboatHost;
+$config["decoupled_preview_iframe.settings"]["preview_url"] = $tugboatHost;


### PR DESCRIPTION
### What does this PR do?

This PR adds a tugboat configuration that will allow this repository to create arbitrary previews; this preview will have its own database, backend and frontend (defaults to next). A base preview will be created manually once these changes are merged to the default branch.

An additional service was included (minio, an S3 compatible storage) to store and read the public URLs for the backend, required for client-side code to reach the backend. Only the frontend and the backend are exposed to the internet.

A patch to enable local settings, and a set of config overrides were included in order to point to the matching frontend of a tugboat build. Also a `replace_preview_consumer.php` script was added so consumer's credentials are set on a preview basis.

Lastly, this base preview will get refreshed every day; reinstalling and updating this Drupal Decoupled project. For new previews only the frontend gets rebuilt, inheriting the base Drupal Decoupled install.