### PR TITLE
✨ feat: output backend, frontend service urls on build

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -147,6 +147,7 @@ services:
         - vendor/bin/drush cache:rebuild
         # Generate a one-time login link.
         - vendor/bin/drush uli -l $TUGBOAT_SERVICE_URL
+        - echo "backend-url:${TUGBOAT_SERVICE_URL}"
 
   frontend:
     image: tugboatqa/debian:bookworm
@@ -213,3 +214,4 @@ services:
         # Warm the cache
         - 'wget -e robots=off --quiet --page-requisites --delete-after --header "Host: ${TUGBOAT_SERVICE_URL_HOST}" http://localhost:8080
           || /bin/true'
+        - echo "frontend-url:${TUGBOAT_SERVICE_URL}"


### PR DESCRIPTION
### What does this PR do?

Updates the tugboat config to output the frontend and backend URLs so are searchable within the logs, it prepends the backend-url/frontend-url identifier.

You can capture the values with:

```typescript
...
# Search Idx
const backendURLIdx = logs.findIndex((log) =>
  log.message.includes("backend-url:"),
);
const frontendURLIdx = logs.findIndex((log) =>
  log.message.includes("frontend-url:"),
);
# Get the values
console.log(
  `backend: ${logs[backendURLIdx + 1].message.replace("backend-url:", "")}`,
);
console.log(
  `frontend: ${logs[frontendURLIdx + 1].message.replace("frontend-url:", "")}`,
);
`
``
