### PR TITLE
🐛 fix: Add missing single quotes to paragraph patch line

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -94,7 +94,7 @@ services:
           set -e
           composer config allow-plugins.cweagans/composer-patches true
           composer config --json extra.composer-exit-on-patch-failure true
-          composer config --json extra.patches.drupal/paragraphs { "Add UUID to table row": "patches/paragraphs-add-uuid-to-table-row.patch" }
+          composer config --json extra.patches.drupal/paragraphs '{ "Add UUID to table row": "patches/paragraphs-add-uuid-to-table-row.patch" }'
           composer require cweagans/composer-patches
         ## Extend Drupal using Recipes
         - |


### PR DESCRIPTION
Now that we're capturing errors, the line that added the paragraph patch was throwing errors as it was malformed.