### PR TITLE
🐛 fix: force frontend rebuild on refresh

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -184,11 +184,12 @@ services:
           curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && bash nodesource_setup.sh
           apt install -y nodejs
           npm install -g yarn
-        # Clone the repository into the service container.
-        - mkdir -p $(dirname /var/lib/tugboat-fe)
-        - git clone https://github.com/octahedroid/drupal-decoupled.git /var/lib/tugboat-fe --depth=1
       update: []
       build:
+        # Clone the repository into the service container.
+        - rm -rf /var/lib/tugboat-fe
+        - mkdir -p /var/lib/tugboat-fe
+        - git clone https://github.com/octahedroid/drupal-decoupled.git /var/lib/tugboat-fe --depth=1
         # Set the frontend framework, replace this line with the framework you are using.
         - echo "next" > /etc/service/frontend/framework
         # Set up environment variables.


### PR DESCRIPTION
This PR should fix the issue on which the frontends were not being updated daily as they were not being rebuilt. Moving the cloning starters step from the `init` to the `build` command.