### PR TITLE
🐛 fix: remove redundant port flag on start

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -217,7 +217,7 @@ services:
         - |
           set -e
           echo "#!/bin/sh" > /etc/service/frontend/run
-          echo "cd /var/lib/tugboat-fe/starters/$(cat /etc/service/frontend/framework) && yarn start --port 8080 $(cat /etc/service/frontend/hostname-flag) 0.0.0.0" >> /etc/service/frontend/run
+          echo "cd /var/lib/tugboat-fe/starters/$(cat /etc/service/frontend/framework) && yarn start $(cat /etc/service/frontend/hostname-flag) 0.0.0.0" >> /etc/service/frontend/run
           chmod +x /etc/service/frontend/run
         - echo "frontend-url:${TUGBOAT_SERVICE_URL}"
       clone:
@@ -246,7 +246,7 @@ services:
         - |
           set -e
           echo "#!/bin/sh" > /etc/service/frontend/run
-          echo "cd /var/lib/tugboat-fe/starters/$(cat /etc/service/frontend/framework) && yarn start --port 8080 $(cat /etc/service/frontend/hostname-flag) 0.0.0.0" >> /etc/service/frontend/run
+          echo "cd /var/lib/tugboat-fe/starters/$(cat /etc/service/frontend/framework) && yarn start $(cat /etc/service/frontend/hostname-flag) 0.0.0.0" >> /etc/service/frontend/run
           chmod +x /etc/service/frontend/run
         - echo "frontend-url:${TUGBOAT_SERVICE_URL}"
 


### PR DESCRIPTION
Both starters (next and remix) already include a default `port` flag set to `8080`, duplicating this flag was causing issues to start the remix application with wrangler:

```
✘ [ERROR] Unexpected options passed to `new Miniflare()` constructor:

  {
    ...,
    port: [ 8080, 8080 ],
          ^ Expected number, received array
    ...,
  }
```

Removing the additional --port flag fixes the issues.